### PR TITLE
Add customizable camera keybindings in Settings > Controls

### DIFF
--- a/src/com/opengg/loader/BrickBench.java
+++ b/src/com/opengg/loader/BrickBench.java
@@ -491,12 +491,8 @@ public class BrickBench extends GGApplication
                 Light.createDirectional(Quaternionf.createXYZ(new Vector3f(0, 0, -0.5f)), new Vector3f(1, 1, 1))));
         WorldEngine.getCurrent().attach(TCSHookManager.enemyManager = new HookCharacterManager());
 
-        BindController.addBind(ControlType.KEYBOARD, "forward", KEY_W);
-        BindController.addBind(ControlType.KEYBOARD, "backward", KEY_S);
-        BindController.addBind(ControlType.KEYBOARD, "left", KEY_A);
-        BindController.addBind(ControlType.KEYBOARD, "right", KEY_D);
-        BindController.addBind(ControlType.KEYBOARD, "up", KEY_SPACE);
-        BindController.addBind(ControlType.KEYBOARD, "down", KEY_LEFT_SHIFT);
+        // Load camera bindings from BrickbenchBindings (customizable via Settings > Controls)
+        BrickbenchBindings.reapplyCameraBindings();
 
         RenderEngine.setProjectionData(ProjectionData.getPerspective(110, 0.2f, 3000f));
 

--- a/src/com/opengg/loader/editor/BrickbenchBindings.java
+++ b/src/com/opengg/loader/editor/BrickbenchBindings.java
@@ -35,6 +35,15 @@ public class BrickbenchBindings {
 
     public static void load(String path){
 
+        // Camera movement bindings (shown in Controls panel)
+        keyMap.put("cam_forward", new Binding("cam_forward","Camera Forward", KeyStroke.getKeyStroke(KeyEvent.VK_W, 0)));
+        keyMap.put("cam_backward", new Binding("cam_backward","Camera Backward", KeyStroke.getKeyStroke(KeyEvent.VK_S, 0)));
+        keyMap.put("cam_left", new Binding("cam_left","Camera Left", KeyStroke.getKeyStroke(KeyEvent.VK_A, 0)));
+        keyMap.put("cam_right", new Binding("cam_right","Camera Right", KeyStroke.getKeyStroke(KeyEvent.VK_D, 0)));
+        keyMap.put("cam_up", new Binding("cam_up","Camera Up", KeyStroke.getKeyStroke(KeyEvent.VK_SPACE, 0)));
+        keyMap.put("cam_down", new Binding("cam_down","Camera Down", KeyStroke.getKeyStroke(KeyEvent.VK_SHIFT, 0)));
+
+        // Hook bindings (shown in Key Bindings panel)
         keyMap.put("teleport1", new Binding("teleport1","Teleport Player 1", KeyStroke.getKeyStroke(KeyEvent.VK_T,0)));
         keyMap.put("teleport2", new Binding("teleport2","Teleport Player 2", KeyStroke.getKeyStroke(KeyEvent.VK_T, KeyEvent.CTRL_MASK | KeyEvent.CTRL_DOWN_MASK)));
         keyMap.put("loadMap1", new Binding("loadMap1","Load Map", KeyStroke.getKeyStroke(KeyEvent.VK_F12, 0)));
@@ -60,6 +69,21 @@ public class BrickbenchBindings {
             GGConsole.log("No Binds File Found. Initializing Default Binds.");
         } catch (IOException e){
             e.printStackTrace();
+        }
+    }
+
+    private static final java.util.Map<String, String> CAM_ACTION_MAP = java.util.Map.of(
+            "cam_forward","forward", "cam_backward","backward",
+            "cam_left","left", "cam_right","right",
+            "cam_up","up", "cam_down","down");
+
+    public static void reapplyCameraBindings() {
+        for (var entry : CAM_ACTION_MAP.entrySet()) {
+            var bind = getOpenGGKeycode(entry.getKey());
+            if (bind != null) {
+                com.opengg.core.engine.BindController.addBind(
+                        new com.opengg.core.io.Bind(com.opengg.core.io.ControlType.KEYBOARD, entry.getValue(), bind.x()));
+            }
         }
     }
 

--- a/src/com/opengg/loader/editor/components/HotkeyButton.java
+++ b/src/com/opengg/loader/editor/components/HotkeyButton.java
@@ -51,6 +51,9 @@ public class HotkeyButton extends JToggleButton implements KeyListener, MouseLis
     public void setBinding(KeyStroke stroke){
         binding.keystroke = stroke;
         BrickbenchBindings.keyMap.put(binding.actionName, binding);
+        if (binding.actionName.startsWith("cam_")) {
+            BrickbenchBindings.reapplyCameraBindings();
+        }
         setText(getKeyText());
         setSelected(false);
     }

--- a/src/com/opengg/loader/editor/windows/SettingsDialog.java
+++ b/src/com/opengg/loader/editor/windows/SettingsDialog.java
@@ -110,7 +110,14 @@ public class SettingsDialog extends JDialog {
                 String.valueOf(sensitivity.getValue()/20f)));
         sensitivity.setToolTipText("Sets the mouse sensitivity for the camera.");
 
-        var fov = new JSlider(JSlider.HORIZONTAL, 30, 150, Integer.parseInt(Configuration.get("fov")));
+        int iFov = 110;
+        try {
+            iFov = Integer.parseInt(Configuration.get("fov"));
+        } catch (NumberFormatException e) {
+            GGConsole.warning("Invalid FOV in config: " + Configuration.get("fov"));
+        }
+
+        var fov = new JSlider(JSlider.HORIZONTAL, 30, 150, iFov);
         fov.setPaintTicks(true);
         fov.setPaintLabels(true);
         fov.setMajorTickSpacing(20);
@@ -135,6 +142,13 @@ public class SettingsDialog extends JDialog {
         addItem("Field of view", fov);
         addItem("Lock camera", camLock);
         addCompactItem("Retain position when loading new maps", retainPos);
+
+        // Camera keybindings
+        for (var entry : BrickbenchBindings.keyMap.entrySet()) {
+            if (entry.getKey().startsWith("cam_")) {
+                addItem(entry.getValue().displayName, new HotkeyButton(entry.getValue(), this));
+            }
+        }
 
         this.settingsPanel.validate();
         this.settingsPanel.repaint();
@@ -292,7 +306,9 @@ public class SettingsDialog extends JDialog {
         resetPanel();
 
         for(Map.Entry<String, BrickbenchBindings.Binding> entry : BrickbenchBindings.keyMap.entrySet()){
-            addItem(entry.getValue().displayName, new HotkeyButton(entry.getValue(), this));
+            if (!entry.getKey().startsWith("cam_")) {
+                addItem(entry.getValue().displayName, new HotkeyButton(entry.getValue(), this));
+            }
         }
 
         this.settingsPanel.validate();
@@ -301,11 +317,16 @@ public class SettingsDialog extends JDialog {
     }
 
     private void resetPanel(){
-        settingsPanel.remove(currentSettingsPanel);
+        settingsPanel.removeAll();
 
         currentSettingsPanel = new JPanel();
-        settingsPanel.add(currentSettingsPanel);
         currentSettingsPanel.setLayout(new MigLayout("wrap 2, fillx, align left top", "[]10[]", "[]15[]"));
+
+        var scrollPane = new JScrollPane(currentSettingsPanel);
+        scrollPane.setBorder(null);
+        scrollPane.getVerticalScrollBar().setUnitIncrement(16);
+        settingsPanel.setLayout(new BorderLayout());
+        settingsPanel.add(scrollPane, BorderLayout.CENTER);
     }
 
     public void addItem(String label, JComponent component){


### PR DESCRIPTION
## Summary

Camera movement keys (WASD, Space, Shift) were hardcoded, making the editor difficult to use on non-QWERTY keyboard layouts (AZERTY, QWERTZ, etc.). This adds them as rebindable entries in **Settings > Controls**, using the existing `BrickbenchBindings` and `HotkeyButton` infrastructure.

<img width="612" height="436" alt="Capture d&#39;écran 2026-04-11 194315" src="https://github.com/user-attachments/assets/906caf1b-d7ff-4647-bd33-532936231cc6" />

### Features
- Bindings are applied **immediately** when changed (no restart needed)
- Persisted in `brickbenchbinds.ini` alongside hook bindings
- Camera bindings shown in **Controls** (where they belong), hook hotkeys stay in **Key Bindings**

### Bonus fixes
- Fix `NumberFormatException` crash when opening Controls with an empty FOV config
- Settings panels are now scrollable

## Changes

| File | Change |
|------|--------|
| `BrickBench.java` | Replace 6 hardcoded `BindController.addBind()` calls with `BrickbenchBindings.reapplyCameraBindings()` |
| `BrickbenchBindings.java` | Add 6 `cam_*` bindings + `reapplyCameraBindings()` method |
| `HotkeyButton.java` | Call `reapplyCameraBindings()` when a `cam_*` binding is changed |
| `SettingsDialog.java` | Show camera bindings in Controls, exclude from Key Bindings, fix FOV crash, add scroll |

## Test plan

- [ ] Open Settings > Controls — camera bindings (Forward, Backward, Left, Right, Up, Down) appear below existing settings
- [ ] Click a camera binding button, press a new key — label updates immediately
- [ ] Navigate the viewport — new key works without restarting
- [ ] Close and reopen BrickBench — bindings persist
- [ ] Settings > Key Bindings only shows hook hotkeys (Teleport, Load Map, etc.)
- [ ] Open Controls with empty/missing FOV config — no crash